### PR TITLE
Fix RLP resolv

### DIFF
--- a/ethereum-lst-defillama.json
+++ b/ethereum-lst-defillama.json
@@ -237,7 +237,7 @@
   },
   {
     "defillamaProps": {
-      "project": "resolv-rlp",
+      "project": "resolv",
       "symbol": "RLP"
     },
     "lstAddresses": [


### PR DESCRIPTION
seems project name changed on defillama yield api, and curve-api returns ethLsdApy 0
![image](https://github.com/user-attachments/assets/d857264d-8b8f-4b34-81e8-5573f9014645)
